### PR TITLE
Update deprecated Claude models to latest versions

### DIFF
--- a/scripts/github_action_javadoc/constants.py
+++ b/scripts/github_action_javadoc/constants.py
@@ -6,7 +6,7 @@ Shared across all modules.
 
 # API Configuration
 CLAUDE_MODEL_OPUS = "claude-opus-4-1-20250805"
-CLAUDE_MODEL_HAIKU = "claude-3-5-haiku-20241022"
+CLAUDE_MODEL_HAIKU = "claude-3-5-haiku-latest"
 MAX_TOKENS = 5000
 
 # API Cost per token (in USD)

--- a/scripts/github_action_javadoc/constants.py
+++ b/scripts/github_action_javadoc/constants.py
@@ -5,7 +5,7 @@ Shared across all modules.
 """
 
 # API Configuration
-CLAUDE_MODEL_OPUS = "claude-opus-4-1-20250805"
+CLAUDE_MODEL_OPUS = "claude-opus-4-latest"
 CLAUDE_MODEL_HAIKU = "claude-3-5-haiku-latest"
 MAX_TOKENS = 5000
 

--- a/scripts/github_action_javadoc/test_javadoc.py
+++ b/scripts/github_action_javadoc/test_javadoc.py
@@ -61,8 +61,8 @@ class TestConfigurationConstants(unittest.TestCase):
 
     def test_action_constants(self):
         """Test action.py constants."""
-        self.assertEqual(CLAUDE_MODEL_OPUS, "claude-opus-4-1-20250805")
-        self.assertEqual(CLAUDE_MODEL_HAIKU, "claude-3-5-haiku-20241022")
+        self.assertEqual(CLAUDE_MODEL_OPUS, "claude-opus-4-latest")
+        self.assertEqual(CLAUDE_MODEL_HAIKU, "claude-3-5-haiku-latest")
         self.assertEqual(MAX_TOKENS, 5000)
         self.assertEqual(OPUS_INPUT_TOKEN_COST, 0.000015)
         self.assertEqual(OPUS_OUTPUT_TOKEN_COST, 0.000075)


### PR DESCRIPTION
## Summary
- Replace deprecated `claude-3-5-haiku-20241022` with `claude-3-5-haiku-latest`
- Replace `claude-opus-4-1-20250805` with `claude-opus-4-latest`
- Using `latest` aliases ensures the code automatically uses current models without needing future updates

## Test plan
- [ ] Verify the action runs successfully on a test PR
- [ ] Confirm no deprecation warnings appear in logs

Fixes INB-1004

🤖 Generated with [Claude Code](https://claude.ai/code)